### PR TITLE
[#13] fix/cesium viewer 높이 설정관련 버그 수정

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,16 +4,15 @@ import SyncControl from './components/toolbar/common/SyncControl';
 
 const App = () => {
   return (
-    <div style={{ width: "100%", height: "100vh", display: "flex", flexDirection: "column" }}>
+    <div style={{ height: "100vh", display: "flex", flexDirection: "column" }}>
       <div style={{ height: "50px", display: "flex", alignItems: "center", justifyContent: "center" }}>
         <SyncControl />
       </div>
-
       <div style={{ display: "flex", flex: 1 }}>
-        <div style={{ flex: 1 }}>
+        <div style={{ display: "flex", flexDirection: 'colum', flex: 1, height: '100%', overflow: 'hidden' }}>
           <OpenLayersMap />
         </div>
-        <div style={{ flex: 1 }}>
+        <div style={{ display: "flex", flexDirection: 'colum', flex: 1, height: '100%', overflow: 'hidden' }}>
           <CesiumMap />
         </div>
       </div>

--- a/src/components/map/CesiumMap.jsx
+++ b/src/components/map/CesiumMap.jsx
@@ -16,9 +16,9 @@ const CesiumMap = () => {
   useInitDataSource(dataSources)
 
   return (
-    <div style={{ display: "flex", flexDirection: "column"}}>
+    <div style={{ flex:1 }}>
       <CesiumInteraction />
-      <div ref={viewContainerRef} style={{ flex: 1, width: '100%' }}></div>
+      <div ref={viewContainerRef} style={{ height: '80vh' }}></div>
     </div>
   );
 };

--- a/src/components/map/OpenLayersMap.jsx
+++ b/src/components/map/OpenLayersMap.jsx
@@ -8,9 +8,9 @@ const OpenLayersMap = () => {
     useInitOlMap(mapRef);
     useInitVectorSource();
     return (
-        <div style={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
+        <div style={{ flex: 1 }}>
             <OpenLayersInteraction /> {/* 툴바 컴포넌트 */}
-            <div ref={mapRef} style={{ flex: 1, width: '100%' }}></div>
+            <div ref={mapRef} style={{ height: '80vh' }}></div>
         </div>
     );
 };


### PR DESCRIPTION
## 관련 이슈 

> #13

## 작업 내용

- [ x ] css 변경

```javascript
// App.jsx
    <div style={{ height: "100vh", display: "flex", flexDirection: "column" }}>
      <div style={{ height: "50px", display: "flex", alignItems: "center", justifyContent: "center" }}>
        <SyncControl />
      </div>
      <div style={{ display: "flex", flex: 1 }}>
        <div style={{ display: "flex", flexDirection: 'colum', flex: 1, height: '100%', overflow: 'hidden' }}>
          <OpenLayersMap />
        </div>
        <div style={{ display: "flex", flexDirection: 'colum', flex: 1, height: '100%', overflow: 'hidden' }}>
          <CesiumMap />
        </div>
      </div>
    </div>

//CesiumMap.jsx
    <div style={{ flex:1 }}>
      <CesiumInteraction />
      <div ref={viewContainerRef} style={{ height: '80vh' }}></div>
    </div>
```

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/85fa337c-6995-41ca-89c3-c98bb7c0989d)

### 참고사항
> 세부 옵션 중 불필요한 옵션도 있으며, 추후 해결 예정