### PR TITLE
[#7] Feature/sync/map 세부로직 변경 (회전값, 상호 호출 루프 오류 존재)

### DIFF
--- a/src/components/toolbar/common/SyncControl.jsx
+++ b/src/components/toolbar/common/SyncControl.jsx
@@ -1,9 +1,9 @@
-import useSyncMap from '../../../hooks/sync/useSyncMap';
+import useSyncMaps from '../../../hooks/sync/useSyncMaps';
 import useSyncObject from '../../../hooks/sync/useSyncObject';
 
 const SyncControl = () => {
 
-  const { isSyncActive, toggleSync } = useSyncMap(); // isSyncActive 값을 useSyncMap에 전달
+  const { isSyncActive, toggleSync } = useSyncMaps(); // isSyncActive 값을 useSyncMap에 전달
   useSyncObject()
   return (
     <div>

--- a/src/hooks/draw/useActivateCesium.js
+++ b/src/hooks/draw/useActivateCesium.js
@@ -114,10 +114,10 @@ const useActivateCesium = ( { label } ) => {
             console.log( "Picked object:", pickedObject );
 
             if ( pickedObject?.id ) {
-                dataSource.entities.remove( pickedObject.id );
                 setSelectedObject?.(
                     convertEntityToStoreSelectedObject( pickedObject.id, ACTIVE_INTERACTIVE_TYPES.REMOVE )
                 );
+                dataSource.entities.remove( pickedObject.id );
             }
         }
     }

--- a/src/hooks/sync/useSyncMaps.js
+++ b/src/hooks/sync/useSyncMaps.js
@@ -5,41 +5,52 @@ import { fromLonLat, toLonLat } from "ol/proj.js";
 import * as Cesium from "cesium";
 
 const UseSyncMaps = () => {
-    const [ isSyncActive, setIsSyncActive ] = useState( false ); // useState로 상태 관리
+    const [isSyncActive, setIsSyncActive] = useState(false); // 상태 관리
+    const [cesiumPointEntity, setCesiumPointEntity] = useState(null); // 중심 좌표 포인트 관리
 
     const toggleSync = () => {
-        setIsSyncActive( ( prev ) => !prev ); // 상태 업데이트
+        setIsSyncActive((prev) => !prev);
     };
 
-    const { cesiumViewer, olMap, centerCoordinates, setCenterCoordinates, rotation, setRotation } = useMapStore(
-        useShallow( ( state ) => ({
+    const { cesiumViewer, olMap } = useMapStore(
+        useShallow((state) => ({
             cesiumViewer: state.cesiumViewer,
             olMap: state.olMap,
-            centerCoordinates: state.centerCoordinates, setCenterCoordinates: state.setCenterCoordinates,
-            rotation: state.rotation, setRotation: state.setRotation,
-        }) )
+        }))
     );
 
-    // OpenLayers에서 중심 좌표 가져오기
-    const getOlMapCenter =  () => {
-        if ( !olMap ) return;
-        const center = olMap.getView().getCenter();
-        if ( !center ) return;
-        const [ lon, lat ] = toLonLat( center );
-        return { lon, lat };
-    }
+    let isUpdatingFromCesium = false; // Cesium에서 업데이트 중인지 추적
+    let isUpdatingFromOpenLayers = false; // OpenLayers에서 업데이트 중인지 추적
 
-    // Cesium에서 중심 좌표 가져오기
+    // OpenLayers 중심 좌표 가져오기
+    const getOlMapCenter = useCallback(() => {
+        if (!olMap) return null;
+        const center = olMap.getView().getCenter();
+        if (!center) return null;
+        const [lon, lat] = toLonLat(center);
+        return { lon, lat };
+    }, [olMap]);
+
+    // OpenLayers 회전 값 가져오기
+    const getOlMapRotation = useCallback(() => {
+        if (!olMap) return 0;
+        const rotation = olMap.getView().getRotation() || 0;
+        return rotation; // OpenLayers는 라디안 사용
+    }, [olMap]);
+
+    // Cesium 중심 좌표 가져오기
     const getCesiumCenter = useCallback(() => {
         if (!cesiumViewer) return null;
 
         const scene = cesiumViewer.scene;
         const camera = scene.camera;
 
-        const ray = camera.getPickRay(new Cesium.Cartesian2(
-            scene.canvas.clientWidth / 2,
-            scene.canvas.clientHeight / 2
-        ));
+        const ray = camera.getPickRay(
+            new Cesium.Cartesian2(
+                scene.canvas.clientWidth / 2,
+                scene.canvas.clientHeight / 2
+            )
+        );
         const intersection = scene.globe.pick(ray, scene);
 
         if (!intersection) return null;
@@ -47,53 +58,123 @@ const UseSyncMaps = () => {
         const lon = Cesium.Math.toDegrees(cartographic.longitude);
         const lat = Cesium.Math.toDegrees(cartographic.latitude);
         return { lon, lat };
-    },[cesiumViewer])
+    }, [cesiumViewer]);
 
-    useEffect( () => {
-        if (!olMap || !isSyncActive) return;
+    // Cesium 중심 좌표 포인트 관리 (값 변경)
+    const updateCesiumPoint = useCallback(
+        (coordinates) => {
+            if (!cesiumViewer || !coordinates) return;
+
+            const { lon, lat } = coordinates;
+
+            if (!cesiumPointEntity) {
+                // 처음 생성 시 엔티티 추가
+                const pointEntity = cesiumViewer.entities.add({
+                    position: Cesium.Cartesian3.fromDegrees(lon, lat),
+                    point: {
+                        pixelSize: 10, // 포인트 크기
+                        color: Cesium.Color.RED.withAlpha(0.8), // 포인트 색상
+                        outlineColor: Cesium.Color.WHITE, // 외곽선 색상
+                        outlineWidth: 2, // 외곽선 두께
+                        heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
+                    },
+                });
+                setCesiumPointEntity(pointEntity);
+            } else {
+                // 기존 포인트의 위치만 변경
+                cesiumPointEntity.position = Cesium.Cartesian3.fromDegrees(lon, lat);
+            }
+        },
+        [cesiumViewer, cesiumPointEntity]
+    );
+
+    // OpenLayers → Cesium 업데이트
+    useEffect(() => {
+        if (!olMap || !cesiumViewer || !isSyncActive) return;
+
         const updateCesiumFromOpenLayers = () => {
-            // console.log("From OpenLayers")
-            const openLayersCenter = getOlMapCenter()
+            if (isUpdatingFromCesium) return;
+            isUpdatingFromOpenLayers = true;
+
+            const openLayersCenter = getOlMapCenter();
+            const openLayersRotation = getOlMapRotation();
+
+            if (!openLayersCenter) return;
+
             const camera = cesiumViewer.scene.camera;
             const cartographic = camera.positionCartographic;
 
-            const newCenter = Cesium.Cartesian3.fromDegrees(openLayersCenter.lon, openLayersCenter.lat, cartographic.height)
+            const newCenter = Cesium.Cartesian3.fromDegrees(
+                openLayersCenter.lon,
+                openLayersCenter.lat,
+                cartographic.height
+            );
 
             camera.setView({
                 destination: newCenter,
                 orientation: {
-                    heading: camera.rotation,
+                    heading: openLayersRotation, // OpenLayers의 회전 값을 Cesium에 반영
                     pitch: camera.pitch,
                     roll: camera.roll,
                 },
             });
-        }
-        olMap.getView().on('change:center', updateCesiumFromOpenLayers);
+
+            // 중심 좌표에 포인트 표시
+            updateCesiumPoint(openLayersCenter);
+
+            isUpdatingFromOpenLayers = false;
+        };
+
+        olMap.getView().on("change:center", updateCesiumFromOpenLayers);
+        olMap.getView().on("change:rotation", updateCesiumFromOpenLayers);
 
         return () => {
-            olMap.getView().un('change:center', updateCesiumFromOpenLayers);
+            olMap.getView().un("change:center", updateCesiumFromOpenLayers);
+            olMap.getView().un("change:rotation", updateCesiumFromOpenLayers);
         };
-    }, [getOlMapCenter, olMap, isSyncActive] );
+    }, [olMap, cesiumViewer, getOlMapCenter, getOlMapRotation, updateCesiumPoint, isSyncActive]);
 
+    const getCesiumRotation = useCallback(() => {
+        if (!cesiumViewer) return 0; // CesiumViewer가 없을 경우 0 반환
+        const camera = cesiumViewer.scene.camera;
+        return camera.heading; // Cesium 카메라의 heading 반환 (라디안 단위)
+    }, [cesiumViewer]);
 
-
+    // Cesium → OpenLayers 업데이트
     useEffect(() => {
-        if (!cesiumViewer || !isSyncActive) return;
+        if (!cesiumViewer || !olMap || !isSyncActive) return;
+
         const updateOpenLayersFromCesium = () => {
-            console.log("FromCesium")
+            if (isUpdatingFromOpenLayers) return;
+            isUpdatingFromCesium = true;
+
             const cesiumCenter = getCesiumCenter();
-            const newCenter = fromLonLat([cesiumCenter.lon, cesiumCenter.lat])
-            olMap.getView().setCenter(newCenter)
-        }
-        cesiumViewer.scene.camera.changed.addEventListener(updateOpenLayersFromCesium);
+            const cesiumRotation = getCesiumRotation();
+
+            if (!cesiumCenter) return;
+
+            const newCenter = fromLonLat([cesiumCenter.lon, cesiumCenter.lat]);
+            olMap.getView().setCenter(newCenter);
+            olMap.getView().setRotation(cesiumRotation); // Cesium의 회전 값을 OpenLayers에 반영
+
+            // 중심 좌표에 포인트 표시
+            updateCesiumPoint(cesiumCenter);
+
+            isUpdatingFromCesium = false;
+        };
+
+        cesiumViewer.scene.preRender.addEventListener(
+            updateOpenLayersFromCesium
+        );
 
         return () => {
-            cesiumViewer.scene.camera.changed.removeEventListener(updateOpenLayersFromCesium);
+            cesiumViewer.scene.preRender.removeEventListener(
+                updateOpenLayersFromCesium
+            );
         };
-    }, [cesiumViewer, getCesiumCenter, isSyncActive]);
+    }, [cesiumViewer, olMap, getCesiumCenter, getCesiumRotation, updateCesiumPoint, isSyncActive]);
 
-
-    return { isSyncActive, toggleSync }
+    return { isSyncActive, toggleSync };
 };
 
 export default UseSyncMaps;

--- a/src/hooks/sync/useSyncMaps.js
+++ b/src/hooks/sync/useSyncMaps.js
@@ -1,0 +1,99 @@
+import { useCallback, useEffect, useState } from "react";
+import useMapStore from "../../store/useMapStore.js";
+import { useShallow } from "zustand/shallow";
+import { fromLonLat, toLonLat } from "ol/proj.js";
+import * as Cesium from "cesium";
+
+const UseSyncMaps = () => {
+    const [ isSyncActive, setIsSyncActive ] = useState( false ); // useState로 상태 관리
+
+    const toggleSync = () => {
+        setIsSyncActive( ( prev ) => !prev ); // 상태 업데이트
+    };
+
+    const { cesiumViewer, olMap, centerCoordinates, setCenterCoordinates, rotation, setRotation } = useMapStore(
+        useShallow( ( state ) => ({
+            cesiumViewer: state.cesiumViewer,
+            olMap: state.olMap,
+            centerCoordinates: state.centerCoordinates, setCenterCoordinates: state.setCenterCoordinates,
+            rotation: state.rotation, setRotation: state.setRotation,
+        }) )
+    );
+
+    // OpenLayers에서 중심 좌표 가져오기
+    const getOlMapCenter =  () => {
+        if ( !olMap ) return;
+        const center = olMap.getView().getCenter();
+        if ( !center ) return;
+        const [ lon, lat ] = toLonLat( center );
+        return { lon, lat };
+    }
+
+    // Cesium에서 중심 좌표 가져오기
+    const getCesiumCenter = useCallback(() => {
+        if (!cesiumViewer) return null;
+
+        const scene = cesiumViewer.scene;
+        const camera = scene.camera;
+
+        const ray = camera.getPickRay(new Cesium.Cartesian2(
+            scene.canvas.clientWidth / 2,
+            scene.canvas.clientHeight / 2
+        ));
+        const intersection = scene.globe.pick(ray, scene);
+
+        if (!intersection) return null;
+        const cartographic = Cesium.Cartographic.fromCartesian(intersection);
+        const lon = Cesium.Math.toDegrees(cartographic.longitude);
+        const lat = Cesium.Math.toDegrees(cartographic.latitude);
+        return { lon, lat };
+    },[cesiumViewer])
+
+    useEffect( () => {
+        if (!olMap || !isSyncActive) return;
+        const updateCesiumFromOpenLayers = () => {
+            // console.log("From OpenLayers")
+            const openLayersCenter = getOlMapCenter()
+            const camera = cesiumViewer.scene.camera;
+            const cartographic = camera.positionCartographic;
+
+            const newCenter = Cesium.Cartesian3.fromDegrees(openLayersCenter.lon, openLayersCenter.lat, cartographic.height)
+
+            camera.setView({
+                destination: newCenter,
+                orientation: {
+                    heading: camera.rotation,
+                    pitch: camera.pitch,
+                    roll: camera.roll,
+                },
+            });
+        }
+        olMap.getView().on('change:center', updateCesiumFromOpenLayers);
+
+        return () => {
+            olMap.getView().un('change:center', updateCesiumFromOpenLayers);
+        };
+    }, [getOlMapCenter, olMap, isSyncActive] );
+
+
+
+    useEffect(() => {
+        if (!cesiumViewer || !isSyncActive) return;
+        const updateOpenLayersFromCesium = () => {
+            console.log("FromCesium")
+            const cesiumCenter = getCesiumCenter();
+            const newCenter = fromLonLat([cesiumCenter.lon, cesiumCenter.lat])
+            olMap.getView().setCenter(newCenter)
+        }
+        cesiumViewer.scene.camera.changed.addEventListener(updateOpenLayersFromCesium);
+
+        return () => {
+            cesiumViewer.scene.camera.changed.removeEventListener(updateOpenLayersFromCesium);
+        };
+    }, [cesiumViewer, getCesiumCenter, isSyncActive]);
+
+
+    return { isSyncActive, toggleSync }
+};
+
+export default UseSyncMaps;

--- a/src/hooks/sync/useSyncObject.js
+++ b/src/hooks/sync/useSyncObject.js
@@ -33,7 +33,7 @@ const useSyncObject = () => {
     useEffect(() => {
         if (!selectedObject) return;
 
-        if (selectedObject.from !== FROM_TYPES.CESIUM || !vectorSource) return;
+        if (selectedObject.from === FROM_TYPES.OPEN_LAYERS || !vectorSource) return;
 
         if (selectedObject.activate === ACTIVE_INTERACTIVE_TYPES.DRAW) {
             // Cesium -> OpenLayers 동기화
@@ -54,12 +54,11 @@ const useSyncObject = () => {
             vectorSource.removeFeature(feature);
         }
 
-
     }, [selectedObject, vectorSource]);
 
     useEffect(() => {
         if (!selectedObject) return;
-        if (selectedObject.from !== FROM_TYPES.OPEN_LAYERS || !dataSource) return;
+        if (selectedObject.from === FROM_TYPES.CESIUM || !dataSource) return;
 
         if (selectedObject.activate === ACTIVE_INTERACTIVE_TYPES.DRAW) {
             // OpenLayers -> Cesium 동기화


### PR DESCRIPTION
## 관련 이슈 

> #7 

## 작업 내용

- [ ] 호출훅 변경  useSyncMap -> useSyncMaps
- [ ] Cesium 중심 값 호출 로직 변경 scene.camera -> camera.getPickRay (카메라와 terrain이 맞닿는 부분을 center로)

## 특이사항

> 1.각 map 간 rotation 사용 범위가 다름 -> cesium 문제 발생, cesium은 heading, pitch roll 모든 값을 하나의 radian으로 계산함, openlayers의 radian과 매칭할 때 여러 부분을 고려해야함, 해당 부분에서 발생하는 부수효과가 다양함
> 2.cesium, openlayers간 sync 시, 상호 호출 루프 문제가 있음 - map 변경, 다른 map에 반영, 반영된 내용을 다시 다른 map에 적용...